### PR TITLE
Remove outline from input and textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-easyforms",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "svelte": "src/index.svelte",
   "module": "index.mjs",
   "main": "index.js",

--- a/src/components/Input.svelte
+++ b/src/components/Input.svelte
@@ -46,6 +46,7 @@
     box-sizing: border-box;
     border: 4px solid #cdd7d6;
     border-radius: 10px;
+    outline: none;
     font-size: 15px;
     padding: 15px;
   }


### PR DESCRIPTION
Small change from this:
![before](https://user-images.githubusercontent.com/5785323/84388554-265d0d80-ac38-11ea-862e-a313b1835731.png)

To this:
![after](https://user-images.githubusercontent.com/5785323/84388567-2a892b00-ac38-11ea-98ff-8eafbc297b08.png)

Accessibility is still maintained as an alternative focus indicator (border color) is being provided.